### PR TITLE
Sample decision records for a11y target & method on projects

### DIFF
--- a/sample_a11y_methods_DR.md
+++ b/sample_a11y_methods_DR.md
@@ -1,0 +1,68 @@
+---
+# Configuration for the Jekyll template "Just the Docs"
+parent: Decisions
+nav_order: 100
+title: Accessibility targets
+
+# These are optional elements. Feel free to remove any of them.
+status: {proposed}
+date: {date of last status update}
+deciders: {people with ultimate decision making power}
+consulted: {people who formed this DR}
+informed: {anyone impacted by this DR}
+---
+<!-- we need to disable MD025, because we use the different heading "ADR Template" in the homepage (see above) than it is foreseen in the template -->
+<!-- markdownlint-disable-next-line MD025 -->
+# Accessibility testing methods
+
+## Context and Problem Statement
+
+Section 508 describes ways we can support people with disabilities, and many accessiblity tech/tools (AT) exist that support various tasks. We on this project team can use those tools to inspect our work, and we can use other tools that can simulate how those tools might work with the code we push to this repository. This decision record sets how we achieve our accessibility target (set in the "Accessibility Target" DR) in an agile way.
+
+## Considered Options
+
+* Review accessibility factors in every PR, where applicable
+* Review accessibility factors at least every other sprint (once per month)
+* Review accessibility factors in the final stages of this project before release
+
+## Decision Outcome
+
+Chosen option: "Review accessibility factors in every PR, where applicable", because our goal is to prioritize accessibility, and this saves us time in the long run by not introducing any problems that could best be fixed at a PR level.
+
+### Consequences
+
+* Good, because it is maximizes accessibility compliance opportunities
+* Good, because it *prevents* accessibility problems from showing up rather than waiting to fix them
+* Good, because it sets a policy that no obvious accessibility problems should ever be merged
+* Neutral, because it a critical feature could be held up by a relatively less critical but still significant accessibility problem (exceptions could fix this)
+* Bad (ish), because it will add about 10 minutes to each PR to thoroughly check accessibility.
+
+### Confirmation
+
+This decision is confirmed by the [Agency] 508 Program Office and by our Contracting Officer's Representative. Project technical staff will continuously confirm adherence to this decision using a PR template, which includes a checklist of items they need to do before it can be merged.
+
+## Pros and Cons of the Options
+
+### Review accessibility factors in every PR, where applicable
+
+* Good, because it is maximizes accessibility compliance opportunities
+* Good, because it *prevents* accessibility problems from showing up rather than waiting to fix them
+* Good, because it sets a policy that no obvious accessibility problems should ever be merged
+* Neutral, because it a critical feature could be held up by a relatively less critical but still significant accessibility problem (exceptions could fix this)
+* Bad (ish), because it will add about 10 minutes to each PR for the submitting engineer and for the (likely designer) accessibility reviewer to thoroughly check accessibility.
+
+### Review accessibility factors at least every other sprint (once per month)
+
+* Good, because it is a relatively frequent check for introduced bugs
+* Neutral, because it sets a middle ground between maximizing accessibility compliance and building capacity
+* Bad, because reviews may catch a lot of bugs and require prioritization work
+
+### Review accessibility factors in the final stages of this project before release
+
+* Good, because it maximizes our capacity for building *something*
+* Bad, because it is the opposite of best practices
+* Bad, because problems discovered at that point may be too many to fix for our deadline
+
+## More Information
+* A sample [PR template](https://github.com/trussworks/accessibility/blob/main/SAMPLE_PR_TEMPLATE.md) and more in-depth [testing instructions](https://github.com/trussworks/accessibility/blob/main/sample_a11y_testing_process.md) can be found on Truss' a11y wiki, which we may copy into our repo to the same end
+* In case a PR for some reason needs to be merged without an an accessibility review, an issue should be made and immediately queued up for work so that any potential issues can be caught as soon as possible.

--- a/sample_a11y_review_DR.md
+++ b/sample_a11y_review_DR.md
@@ -1,0 +1,73 @@
+---
+# Configuration for the Jekyll template "Just the Docs"
+parent: Decisions
+nav_order: 100
+title: "Design & a11y reviews"
+
+# These are optional elements. Feel free to remove any of them.
+status: "Proposed"
+date: "2023-08-04"
+deciders: "Design/A11y lead"
+consulted: "All designers"
+informed: "All project technical staff"
+---
+<!-- we need to disable MD025, because we use the different heading "ADR Template" in the homepage (see above) than it is foreseen in the template -->
+<!-- markdownlint-disable-next-line MD025 -->
+# Accessibility testing methods
+
+## Context and Problem Statement
+
+In order to work in an agile fashion and ensure code changes meet both design spec and our [accessibility target](sample_a11y_target_DR.md), we should align on a consistent process to achieve this. As part of the [accessibility review](sample_a11y_method_DR.md) for each [PR](SAMPLE_PR_TEMPLATE.md), the original developer will do a first pass of both design and a11y review. This DR covers how designers will be the second set of eyes on those user-facing changes.
+
+## Considered Options
+* Review each PR locally before merging
+* Review all merged PRs for the current sprint in the deployment environment at the end of the sprint
+* Review entire application in the deployment environment every other sprint
+* Review entire application in the deployment environment when designers are available
+
+## Decision Outcome
+
+Chosen option: "Review all merged PRs for the current sprint in the deployment environment at the end of the sprint", because it is the best we can reasonably do given our comfort with the tools and time available.
+
+### Consequences
+
+* Good, because it maximizes coverage
+* Good, because it does a decent job of preventing issues from sneaking by for more than a sprint
+* Bad, because it requires extra time to create a new issue for each problem discovered
+* Bad, because it requires extra time to filter Github PRs by date
+
+### Confirmation
+
+This decision is confirmed by all designers, as they will be doing this work.
+
+## Pros and Cons of the Options
+
+### Review each PR locally before merging
+
+* Good, because it maximizes coverage of changes
+* Good, because it prevents almost all issues from sneaking by
+* Good, because feedback can go directly into the [PR](SAMPLE_PR_TEMPLATE.md)
+* Bad, because it requires frequent intervention by designers who may not be comfortable with necessary tools
+
+### Review all merged PRs for the current sprint in the deployment environment at the end of the sprint
+
+* Good, because it maximizes coverage of changes
+* Good, because it does a decent job of preventing issues from sneaking by for more than a sprint
+* Bad, because it requires extra time to create a new issue for each problem discovered
+* Bad, because it requires extra time to filter Github PRs by date
+
+### Review entire application in the deployment environment every other sprint
+
+* Good, because it maximizes coverage of the final user experience (end to end)
+* Neutral, because it does a decent job of preventing issues from sneaking by for more than two sprints, but can mean more work is needed to recover from it
+* Bad, because it requires extra time and cognitive load to check what was merged and identifying in the environment what to review. It's more likely in two vs one sprint that multiple PRs covered a certain page/feature, so filtering PRs by date is less useful.
+* Bad, because it requires extra time to create a new issue for each problem discovered
+
+### Review entire application in the deployment environment when designers are available
+* Neutral, because it could maximize coverage of the final user experience (end to end), but only as much as the designer has time for
+* Bad, because lingering design/a11y debt can be harder to pay off the longer it lingers
+* Bad, because it requires extra time and cognitive load to check what was merged and identifying in the environment what to review. It's higly likely that multiple PRs covered a certain page/feature, so filtering PRs by date is useless.
+* Bad, because it requires extra time to create a new issue for each problem discovered
+
+## More Information
+* The design review checklist is located in the [PR template](SAMPLE_PR_TEMPLATE.md) for the first option and in a [separate document](sample_a11y_testing_process.md) for all other options.

--- a/sample_a11y_review_process.md
+++ b/sample_a11y_review_process.md
@@ -1,0 +1,38 @@
+# Design and a11y review process
+
+Per our [design review DR](adr_design-review.md), The below steps are specifically the design and accessibility testing part of the overall acceptance flow process. The code submitter should have done their due dilligence for any user interface changes so that a design/a11y reviewer can focus on finer details. Although there are several steps, if we do this regularly it will be a light lift and will avoid any design/a11y debt.
+
+## Get ready
+
+1. Consider conducting this with your engineer, who can help diagnose and articulate problems and solutions to what you may find in this process.
+2. Load the [frontend application](https://truss.works) (this updates on every merge to the [main](https://github.com/trussworks/accessibility/main) branch)
+3. Open the PR(s) with the https://github.com/trussworks/accessibility/labels/needs%20design%20review label to review.
+4. Use the checklist in the next section to review the changes, noting what the original developer checked off in their "user-facing" checklist
+5. For each PR you review, remove the https://github.com/trussworks/accessibility/labels/needs%20design%20review label
+6. Create a [new issue](https://github.com/trussworks/accessibility/issues/new/choose) with the "Bug" template, and document a problem you find, linking to the relevant PR and `@`ing the original developer for context (don't "assign" unless they're ok with it).
+   * Repeat this step for each issue you find. To help engineers portion and pace work, it's usually best to not bundle everything into a single issue. Instead, use one issue for each discrepancy or highly related group of discrepancies.
+
+## Verify that any changes match the design intention
+
+- [ ] Check that the design translated visually
+- [ ] Check interaction behavior
+- [ ] Check different states (empty, one, some, error)
+- [ ] Check for landmarks, page heading structure, and links
+- [ ] Try to break the intended flow
+- [ ] Confirm this works at 5Mbps down and 1Mbps up. You might use [Firefox dev tools](https://firefox-source-docs.mozilla.org/devtools-user/network_monitor/throttling/index.html) or Chrome's [WebRTC Network Limiter](https://chrome.google.com/webstore/detail/webrtc-network-limiter/npeicpdbkakmehahjeeohfdhnlpdklia)
+
+## Verify that any changes meet accessibility targets
+
+- [ ] Check responsiveness in mobile, tablet, and desktop at 200% zoom
+- [ ] Check keyboard navigability
+
+* Test general usability, landmarks, page header structure, and links with a screen reader (different from what the original dev used in their checklist):
+  - [ ] [VoiceOver](https://dequeuniversity.com/screenreaders/voiceover-keyboard-shortcuts#vo-mac-basics) in Safari
+  - [ ] [JAWS](https://dequeuniversity.com/screenreaders/jaws-keyboard-shortcuts#jaws-the_basics) in Chrome
+  - [ ] [NVDA](https://dequeuniversity.com/screenreaders/nvda-keyboard-shortcuts#nvda-the_basics) in Chrome
+* Use an a11y tool to check these changes conform to at least WCAG 2.1 AA
+  - [ ] [WAVE](https://wave.webaim.org/)
+  - [ ] [axe](https://www.deque.com/axe/devtools/)
+  - [ ] [ANDI](https://www.ssa.gov/accessibility/andi/help/install.html#install)
+  - [ ] Browser inspector ([firefox](https://firefox-source-docs.mozilla.org/devtools-user/accessibility_inspector/#accessing-the-accessibility-inspector) / [chrome](https://developer.chrome.com/docs/lighthouse/accessibility/))
+  - [ ] For storybook-only components, use its [accessibility addon](https://medium.com/storybookjs/instant-accessibility-qa-linting-in-storybook-4a474b0f5347#c703).

--- a/sample_a11y_target_DR.md
+++ b/sample_a11y_target_DR.md
@@ -17,7 +17,7 @@ informed: {anyone impacted by this DR}
 
 ## Context and Problem Statement
 
-In supporting a critical task for all U.S. residents, Direct File should be accessible. This decision record sets a clear target for this phase of development to meet those accessibility needs, and we expect to exceed that target when feasible.
+In supporting a critical task for all U.S. residents, our product should be accessible. This decision record sets a clear target for this phase of development to meet those accessibility needs, and we expect to exceed that target when feasible.
 
 The U.S. describes its accessiblity requirements in [Section 508](https://www.section508.gov/) of the Rehabilitation Act. [WCAG](https://www.w3.org/WAI/standards-guidelines/wcag/) provides the same for the internet at large with three levels of compliance (A, AA, AAA), and it has increased in minor versions (2.0, 2.1, 2.2) over the last 15 years. 508 and WCAG have a [very large overlap](https://www.access-board.gov/ict/#E207.2), and all non-overlapping features unique to 508 are either irrelevant to this project (e.g. manual operation and hardware) or out of this repo's scope (e.g. support channels). See the note in "More Information" below for further information.
 
@@ -74,7 +74,7 @@ This decision is confirmed by the [Agency] 508 Program Office and by our Contrac
 * Good, because it establishes and exceeds 508 compliance
 * Good, because it is easy to remember the level expected of all elements (i.e. "what needs level A vs AA?")
 * Good, because it challenges us to maximize WCAG at level AAA
-* Good, because it sets Direct File up with the latest a11y guidance for years to come
+* Good, because it sets us up with the latest a11y guidance for years to come
 * Good, because it doesn't require any more work than WCAG 2.1 AA
 * Neutral, because it may require slighly more work than the bare minimum
 * Neutral, because it is not yet fully published as of this writing and may have very minor [changes](https://www.w3.org/WAI/standards-guidelines/wcag/new-in-22/#changes-to-the-22-draft) between now and then.

--- a/sample_a11y_target_DR.md
+++ b/sample_a11y_target_DR.md
@@ -1,0 +1,95 @@
+---
+# Configuration for the Jekyll template "Just the Docs"
+parent: Decisions
+nav_order: 100
+title: Accessibility targets
+
+# These are optional elements. Feel free to remove any of them.
+status: {proposed}
+date: {date of last status update}
+deciders: {people with ultimate decision making power}
+consulted: {people who formed this DR}
+informed: {anyone impacted by this DR}
+---
+<!-- we need to disable MD025, because we use the different heading "ADR Template" in the homepage (see above) than it is foreseen in the template -->
+<!-- markdownlint-disable-next-line MD025 -->
+# Accessibility targets
+
+## Context and Problem Statement
+
+In supporting a critical task for all U.S. residents, Direct File should be accessible. This decision record sets a clear target for this phase of development to meet those accessibility needs, and we expect to exceed that target when feasible.
+
+The U.S. describes its accessiblity requirements in [Section 508](https://www.section508.gov/) of the Rehabilitation Act. [WCAG](https://www.w3.org/WAI/standards-guidelines/wcag/) provides the same for the internet at large with three levels of compliance (A, AA, AAA), and it has increased in minor versions (2.0, 2.1, 2.2) over the last 15 years. 508 and WCAG have a [very large overlap](https://www.access-board.gov/ict/#E207.2), and all non-overlapping features unique to 508 are either irrelevant to this project (e.g. manual operation and hardware) or out of this repo's scope (e.g. support channels). See the note in "More Information" below for further information.
+
+Given these equivalencies, all considered options are oriented toward WCAG and achieve 508 compliance.
+
+## Considered Options
+
+* WCAG 2.0 A and AA (base 508)
+* WCAG 2.1 A and AA (508 superset)
+* WCAG 2.1 AA (enhanced superset)
+* WCAG 2.2 AA (forward-thinking)
+
+## Decision Outcome
+
+Chosen option: "WCAG 2.1 AA (enhanced superset)", because it meets our accessibility goal, enables us to exceed it, and sets us up to upgrade to the next version once it's official.
+
+### Consequences
+
+* Good, because it establishes and exceeds 508 compliance
+* Good, because it is easy to remember the level expected of all elements (i.e. "what needs level A vs AA?")
+* Good, because it challenges us to maximize WCAG at level AAA
+* Neutral, because it may require slighly more work than the bare minimum
+* Neutral, because it will be an outdated version before the project ends, but once 2.2 is ready it'd be trivial to change this DR to match (see "more information" below).
+
+### Confirmation
+
+This decision is confirmed by the [Agency] 508 Program Office and by our Contracting Officer's Representative. Project technical staff will continuously confirm adherence to this decision using accesibility evaluation tools and manual evaluations when/where appropriate.
+
+## Pros and Cons of the Options
+
+### WCAG 2.0 A and AA (base 508)
+
+* Good, because it establishes 508 compliance
+* Good, because it is the easiest level to achieve
+* Bad, because omits updates and new tech since its publication 15 years ago
+* Bad, because it does not exceed 508 compliance, as called for in our mission
+
+### WCAG 2.1 A and AA (508 superset)
+
+* Good, because it establishes 508 compliance
+* Good, because it is the easiest level to achieve for the latest published guidance
+* Bad, because it does not exceed 508 compliance, as called for in our mission, for the latest technologies like mobile devices
+
+### WCAG 2.1 AA (enhanced superset)
+
+* Good, because it establishes and exceeds 508 compliance
+* Good, because it is easy to remember the level expected of all elements (i.e. "what needs level A vs AA?")
+* Good, because it challenges us to maximize WCAG at level AAA
+* Neutral, because it may require slighly more work than the bare minimum
+* Neutral, because it will be an outdated version before the project ends, but once 2.2 is ready it'd be trivial to change this DR to match (see "more information" below).
+
+### WCAG 2.2 AA (forward-thinking)
+
+* Good, because it establishes and exceeds 508 compliance
+* Good, because it is easy to remember the level expected of all elements (i.e. "what needs level A vs AA?")
+* Good, because it challenges us to maximize WCAG at level AAA
+* Good, because it sets Direct File up with the latest a11y guidance for years to come
+* Good, because it doesn't require any more work than WCAG 2.1 AA
+* Neutral, because it may require slighly more work than the bare minimum
+* Neutral, because it is not yet fully published as of this writing and may have very minor [changes](https://www.w3.org/WAI/standards-guidelines/wcag/new-in-22/#changes-to-the-22-draft) between now and then.
+
+## More Information
+
+* For a complete description of Section 508, see https://www.access-board.gov/ict/
+  * WCAG 2.1 is a superset of WCAG 2.0, which will be the official 508 version until Access Board approves an update, which can take years.
+* Most automated testing tools use version 2.1, so 2.0 compliance may appear as failing on tools and 2.2 may not be available. In 2.2's case, it is largely backwards-compatible to 2.1 AA assuming all other criteria are met; therefore, if tools don't reflect 2.2 we can treat their 2.1 AA conformance as equivalent.
+* Most testing tools are focused on level (A, AA, AAA) of compliance, so setting level AA as our target would be more memorable, programmable, and communicable.
+* How we achieve these targets, including tooling and processes, are described in a separate decision record.
+* WCAG 3 is still in a working draft phase, but it provides some guidance that may be truly better but technically non-compliant with 2.2 due to backward incompatibility. For example, WCAG 3.0 uses a new [color contrast algorithm (APCA)](https://github.com/Myndex/SAPC-APCA/blob/master/documentation/WhyAPCA.md#why-the-new-contrast-method-apca/) that better matches reality. In our effort to exceed targets, we may want to use [this calculator](http://www.myndex.com/APCA/) to test contrast among other things to allow us to both exceed our targets and be forward-thinking.
+* Things 508 covers that WCAG does not explicitly (TLDR: there are no issues):
+  * **Functional Performance Criteria**: at least one method must be provided allowing individuals with disabilities to interact with the product. Most of these are [explicitly covered by WCAG](https://www.section508.gov/content/mapping-wcag-to-fpc/), but two are not:
+    * Without Speech - where speech is used for input, control or operation, ICT will provide at least one mode of operation that does not require user speech. We will not have any speech-based features built into this project, so this is not an issue.
+    * With Limited Reach and Strength - where a manual mode of operation is provided, ICT will provide at least one mode of operation that is operable with limited reach and limited strength. We will not have any manual operation methods, so this is not an issue.
+  * **Hardware and software**: 508 applies to websites like this, as well as hardware and operating systems. We are not building these, so this is not an issue.
+  * **Alternative Means of Communication**: 508 ensures that people with disabilities can effectively communicate and interact with support personnel. Examples of alternative means of communication include relay services for individuals with hearing impairments or providing accessible contact options for individuals with disabilities.


### PR DESCRIPTION
This adds sample decision records for setting an accessibility target and methods to reach it, to be used on projects (internal and external)

- Adds three DR samples and a sample guide
- Separately, added links to https://github.com/trussworks/accessibility/wiki/Accessibility-Scorecard
